### PR TITLE
Type fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .DS_Store
 package-lock.json
+yarn.lock
 coverage
 .nyc_output
 .cache

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "lib/index.js"
   ],
   "scripts": {
-    "build": "rimraf lib/ && tsc && babel src --out-dir lib --extensions \".ts\" --ignore \"**/*.test.ts\"",
+    "build": "rimraf lib/ && tsc && babel src --out-dir lib --extensions \".ts\" && rimraf lib/**.test* && tsd",
     "test": "jest",
     "test-watch": "jest --watch",
+    "test-types": "tsd",
     "lint": "eslint src/**",
     "lint-fix": "eslint src/** --fix",
     "pre-commit": "lint-staged --quiet && npm run build",
@@ -48,6 +49,7 @@
     "npm-check-updates": "^10.2.2",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
+    "tsd": "^0.14.0",
     "typescript": "^4.1.2"
   },
   "husky": {
@@ -62,5 +64,8 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "tsd": {
+    "directory": "src"
   }
 }

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -1,23 +1,42 @@
 import {Projection} from './'
 import {expectType} from 'tsd'
+import {pipe} from 'fp-ts/function'
 
-type A = {a: string}
-type B = {b: number}
-type C = {c: 'c'}
-type D = {d: Date}
+type A = string
+type B = number
+type C = 'c'
+type D = Date
 type S = {a: A; b: B; c: C; d: D}
-const s: S = {a: {a: 'a value'}, b: {b: 7}, c: {c: 'c'}, d: {d: new Date()}}
 
 const p1 = Projection.fromProp<S>()('a')
 const p2 = Projection.fromProp<S>()('b')
 const p3 = Projection.fromProp<S>()('c')
 const p4 = Projection.fromProp<S>()('d')
 
-const combined = p1.combine([p2, p3, p4] as const, (a, b, c, d) => `${a.a}-${b.b}-${c.c}-${d.d}`)
-expectType<Projection<S, string>>(combined)
+expectType<Projection<S, string>>(
+  p1.combine([p2, p3, p4] as const, (a, b, c, d) => `${a}-${b}-${c}-${d}`)
+)
+expectType<Projection<S, string>>(
+  Projection.mapN([p1, p2, p3, p4] as const, (a, b) => [a, b].join(''))
+)
+expectType<Projection<S, string>>(
+  Projection.mapN([p1, p2, p3, p4] as const, (a, b, c) => [a, b, c].join(''))
+)
+expectType<Projection<S, string>>(
+  Projection.mapN([p1, p2, p3, p4] as const, (a, b, c, d) => [a, b, c, d].join(''))
+)
 
-expectType<string>(combined.get(s))
-const fromMapN = Projection.mapN([p1, p2] as const, (a, b) => `${a.a}-${b.b}`)
+expectType<Projection<S, string>>(
+  pipe(
+    [p1, p2, p3, p4] as const,
+    Projection.mapF((a, b, c, d) => [a, b, c, d].join(''))
+  )
+)
+expectType<Projection<S, {value: Array<A | B | C | D>}>>(
+  pipe(
+    [p1, p2, p3, p4] as const,
+    Projection.mapF((a, b, c, d) => ({value: [a, b, c, d]}))
+  )
+)
 
-expectType<Projection<S, string>>(fromMapN)
-expectType<string>(fromMapN.get(s))
+expectType<[Projection<S, A>, Projection<S, B>, Projection<S, C>]>(Projection.merge(p1, p2, p3))

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -14,9 +14,17 @@ const pB = Projection.fromProp<S>()('b')
 const pC = Projection.fromProp<S>()('c')
 const pD = Projection.fromProp<S>()('d')
 
-// combine returns the correct type and infers the right types for the function parameters
+// Projection.combine returns the correct type and infers the right types for the function parameters
 expectType<Projection<S, string>>(
-  pA.combine([pB, pC, pD] as const, (a, b, c, d) => {
+  pA.combine(pB, (a, b) => {
+    expectType<A>(a)
+    expectType<B>(b)
+    return `${a}-${b}`
+  })
+)
+
+expectType<Projection<S, string>>(
+  pA.combine([pB, pC, pD], (a, b, c, d) => {
     expectType<A>(a)
     expectType<B>(b)
     expectType<C>(c)
@@ -25,7 +33,7 @@ expectType<Projection<S, string>>(
   })
 )
 
-// mapN returns the correct type and infers the right types for the function parameters
+// Projection.mapN returns the correct type and infers the right types for the function parameters
 expectType<Projection<S, string>>(
   Projection.mapN([pA, pB], (a, b) => {
     expectType<A>(a)
@@ -53,7 +61,7 @@ expectType<Projection<S, string>>(
   })
 )
 
-// mapF returns the correct type and infers the right types for the function parameters with a const tuple
+// Projection.mapF returns the correct type and infers the right types for the function parameters with a const tuple
 expectType<Projection<S, string>>(
   pipe(
     [pA, pB, pC, pD] as const,
@@ -67,7 +75,7 @@ expectType<Projection<S, string>>(
   )
 )
 
-// mapF returns the correct type and infers the right types for the function parameters via Projection.merge
+// Projection.mapF returns the correct type and infers the right types for the function parameters via Projection.merge
 expectType<Projection<S, string>>(
   pipe(
     Projection.merge(pA, pB, pC, pD),

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -1,0 +1,23 @@
+import {Projection} from './'
+import {expectType} from 'tsd'
+
+type A = {a: string}
+type B = {b: number}
+type C = {c: 'c'}
+type D = {d: Date}
+type S = {a: A; b: B; c: C; d: D}
+const s: S = {a: {a: 'a value'}, b: {b: 7}, c: {c: 'c'}, d: {d: new Date()}}
+
+const p1 = Projection.fromProp<S>()('a')
+const p2 = Projection.fromProp<S>()('b')
+const p3 = Projection.fromProp<S>()('c')
+const p4 = Projection.fromProp<S>()('d')
+
+const combined = p1.combine([p2, p3, p4] as const, (a, b, c, d) => `${a.a}-${b.b}-${c.c}-${d.d}`)
+expectType<Projection<S, string>>(combined)
+
+expectType<string>(combined.get(s))
+const fromMapN = Projection.mapN([p1, p2] as const, (a, b) => `${a.a}-${b.b}`)
+
+expectType<Projection<S, string>>(fromMapN)
+expectType<string>(fromMapN.get(s))

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -75,10 +75,10 @@ expectType<Projection<S, string>>(
   )
 )
 
-// Projection.mapF returns the correct type and infers the right types for the function parameters via Projection.merge
+// Projection.mapF returns the correct type and infers the right types for the function parameters via Projection.createTuple
 expectType<Projection<S, string>>(
   pipe(
-    Projection.merge(pA, pB, pC, pD),
+    Projection.createTuple(pA, pB, pC, pD),
     Projection.mapF((a, b, c, d) => {
       expectType<A>(a)
       expectType<B>(b)
@@ -96,11 +96,13 @@ expectType<Projection<S, {value: Array<A | B | C | D>}>>(
   )
 )
 
-// Projection.merge returns a strongly-typed tuple
-expectType<[Projection<S, A>, Projection<S, B>, Projection<S, C>]>(Projection.merge(pA, pB, pC))
+// Projection.createTuple returns a strongly-typed tuple
+expectType<[Projection<S, A>, Projection<S, B>, Projection<S, C>]>(
+  Projection.createTuple(pA, pB, pC)
+)
 
-// Projection.merge returns a strongly-typed tuple with different gettable types
+// Projection.createTuple returns a strongly-typed tuple with different gettable types
 
 const lA = Lens.fromProp<S>()('a')
 const lC = pipe(lens.id<S>(), lens.prop('c'))
-expectType<[Lens<S, A>, Projection<S, B>, lens.Lens<S, C>]>(Projection.merge(lA, pB, lC))
+expectType<[Lens<S, A>, Projection<S, B>, lens.Lens<S, C>]>(Projection.createTuple(lA, pB, lC))

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -74,7 +74,7 @@ describe('Projection.combine', () => {
     expect(combined).toBeInstanceOf(Projection)
   })
 
-  test('can merge different kinds of gettables', () => {
+  test('can combine different kinds of gettables', () => {
     type A = {value: string}
     type B = {type: number}
     type C = {foo: boolean}

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -65,7 +65,7 @@ describe('Projection.combine', () => {
     const p3 = Projection.fromProp<S>()('c')
     const p4 = Projection.fromProp<S>()('d')
     const combined = p1.combine(
-      [p2, p3, p4] as const,
+      [p2, p3, p4],
       (a, b, c, d) => `${a.aValue}-${b.bValue}-${c.cValue}-${d.dValue}`
     )
     const expected = `${s.a.aValue}-${s.b.bValue}-${s.c.cValue}-${s.d.dValue}`
@@ -83,7 +83,7 @@ describe('Projection.combine', () => {
     const p1 = Projection.fromProp<S>()('a')
     const p2 = {get: (s: S) => s.b}
     const p3 = Lens.fromProp<S>()('c')
-    const combined = p1.combine([p2, p3] as const, (a, b, c) => ({
+    const combined = p1.combine([p2, p3], (a, b, c) => ({
       d: `${a.value}-${b.type}-${c.foo}`
     }))
     const expected = {d: `${s.a.value}-${s.b.type}-${s.c.foo}`}
@@ -101,7 +101,7 @@ describe('Projection.mapN', () => {
     const s: S = {a: {value: 'value'}, b: {type: 1}}
     const p1 = Projection.fromProp<S>()('a')
     const p2 = Projection.fromProp<S>()('b')
-    const combined = Projection.mapN([p1, p2] as const, (a, b) => ({c: `${a.value}-${b.type}`}))
+    const combined = Projection.mapN([p1, p2], (a, b) => ({c: `${a.value}-${b.type}`}))
     const expected = {c: `${s.a.value}-${s.b.type}`}
     const actual = combined.get(s)
     expect(actual).toEqual(expected)
@@ -120,7 +120,7 @@ describe('Projection.mapN', () => {
     const p3 = Projection.fromProp<S>()('c')
     const p4 = Projection.fromProp<S>()('d')
     const combined = Projection.mapN(
-      [p1, p2, p3, p4] as const,
+      [p1, p2, p3, p4],
       (a, b, c, d) => `${a.aValue}-${b.bValue}-${c.cValue}-${d.dValue}`
     )
     const expected = `${s.a.aValue}-${s.b.bValue}-${s.c.cValue}-${s.d.dValue}`
@@ -138,7 +138,7 @@ describe('Projection.mapN', () => {
     const p1 = Projection.fromProp<S>()('a')
     const p2 = {get: (s: S) => s.b}
     const p3 = Lens.fromProp<S>()('c')
-    const combined = Projection.mapN([p1, p2, p3] as const, (a, b, c) => ({
+    const combined = Projection.mapN([p1, p2, p3], (a, b, c) => ({
       d: `${a.value}-${b.type}-${c.foo}`
     }))
     const expected = {d: `${s.a.value}-${s.b.type}-${s.c.foo}`}

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -1,6 +1,6 @@
 import {Projection} from './projection'
 import {Lens, Getter} from 'monocle-ts'
-import {pipe} from 'fp-ts/lib/pipeable'
+import {pipe} from 'fp-ts/function'
 
 test('Projection.fromProp: drills down to an objects prop', () => {
   type S = {a: string}

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -42,14 +42,6 @@ export type GettableTuple<S, Tuple extends TupleType> = {
 } & {
   readonly length: Tuple['length']
 }
-
-export type ProjectionMapFunction<
-  Projections extends TupleType,
-  Return
-> = Projections extends GettableTuple<infer _, infer Args>
-  ? (...args: Args) => Return
-  : (...args: unknown[]) => Return
-
 export class Projection<S, A> implements Gettable<S, A> {
   private readonly getter: Getter<S, A>
 
@@ -111,23 +103,22 @@ export class Projection<S, A> implements Gettable<S, A> {
    * declare const p1 : Projection<S,A>
    * declare const p2 : { get: (s: S) => B }
    * declare const p3 : Lens<S, A>
-   * const combined = p1.combine([p2, p3] as const, (a, b, c) => ({
+   * const combined = p1.combine([p2, p3], (a, b, c) => ({
    *   d: `${a.foo}-${b.bar}-${c.baz}`
    * }))
    */
   /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
-  public combine<Types extends TupleType, R>(
-    ss: GettableTuple<S, Types>,
-    f: FunctionN<[A, ...Types], R>
+  public combine<B, T extends TupleType, R>(
+    ss: GettableTuple<S, [B, ...T]>,
+    f: FunctionN<[A, B, ...T], R>
   ): Projection<S, R>
   public combine<B, R>(ss: Gettable<S, B>, f: FunctionN<[A, B], R>): Projection<S, R>
-  public combine<Types extends TupleType, R>(ss: any, f: any): Projection<S, R> {
-    const ps: GettableTuple<S, [A, ...Types]> = Array.isArray(ss)
-      ? [this, ...ss]
-      : ([this, ss] as any)
+  public combine<T extends TupleType, R>(ss: any, f: any): Projection<S, R> {
+    const ps: GettableTuple<S, [A, ...T]> = Array.isArray(ss) ? [this, ...ss] : ([this, ss] as any)
 
     return Projection.mapN(ps, f)
   }
+
   /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
   public map<B>(f: (a: A) => B): Projection<S, B> {
     return Projection.map(this, f)
@@ -176,22 +167,21 @@ export class Projection<S, A> implements Gettable<S, A> {
   /**
    * Merge one or more projection-like objects with the provided mapping function.
    *
-   * To get type inferrence working properly, you may need to use `as const`
    * @example
    * declare const p1 : Projection<S,A>
    * declare const p2 : { get: (s: S) => B }
    * declare const p3 : Lens<S, A>
-   * const combined = Projection.mapN([p1, p2, p3] as const, (a, b, c) => ({
+   * const combined = Projection.mapN([p1, p2, p3], (a, b, c) => ({
    *   d: `${a.foo}-${b.bar}-${c.baz}`
    * }))
    */
-  public static mapN<S, A, Types extends TupleType, R>(
-    projections: GettableTuple<S, [A, ...Types]>,
-    f: FunctionN<[A, ...Types], R>
+  public static mapN<S, A, T extends TupleType, R>(
+    projections: GettableTuple<S, [A, ...T]>,
+    f: FunctionN<[A, ...T], R>
   ): Projection<S, R> {
     return Projection.of(
       flow(
-        s => projections.map(p => p.get(s)) as [A, ...Types],
+        s => projections.map(p => p.get(s)) as [A, ...T],
         p => f(...p)
       )
     )
@@ -199,6 +189,7 @@ export class Projection<S, A> implements Gettable<S, A> {
 
   /**
    * Same as `mapN`, but in a format that can be piped.
+   * To get type inference working properly, you may need to use `as const` or Projection.merge
    * @example
    * const combined = pipe(
    *   [p1, p2, p3] as const,
@@ -206,9 +197,16 @@ export class Projection<S, A> implements Gettable<S, A> {
    *     d: `${a.value}-${b.type}-${c.foo}`
    *   }))
    * )
+   * // Or:
+   * const combined = pipe(
+   *   Projection.merge(p1, p2, p3),
+   *   Projection.pipeMap((a, b, c) => ({
+   *     d: `${a.value}-${b.type}-${c.foo}`
+   *   }))
+   * )
    */
-  public static mapF<A, Types extends TupleType, R>(f: (...args: [A, ...Types]) => R) {
-    return <S>(projections: GettableTuple<S, [A, ...Types]>): Projection<S, R> => {
+  public static mapF<A, T extends TupleType, R>(f: FunctionN<[A, ...T], R>) {
+    return <S>(projections: GettableTuple<S, [A, ...T]>): Projection<S, R> => {
       return Projection.mapN(projections, f)
     }
   }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -96,7 +96,7 @@ export class Projection<S, A> implements Gettable<S, A> {
   /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 
   /**
-   * Merge one or more projection-like objects with the provided mapping function.
+   * Combine one or more projection-like objects with the provided mapping function.
    *
    * To get type inference working properly, you may need to use `as const`
    * @example
@@ -165,7 +165,7 @@ export class Projection<S, A> implements Gettable<S, A> {
   }
 
   /**
-   * Merge one or more projection-like objects with the provided mapping function.
+   * Combine one or more projection-like objects with the provided mapping function.
    *
    * @example
    * declare const p1 : Projection<S,A>
@@ -189,7 +189,7 @@ export class Projection<S, A> implements Gettable<S, A> {
 
   /**
    * Same as `mapN`, but in a format that can be piped.
-   * To get type inference working properly, you may need to use `as const` or Projection.merge
+   * To get type inference working properly, you may need to use `as const` or Projection.createTuple
    * @example
    * const combined = pipe(
    *   [p1, p2, p3] as const,
@@ -199,7 +199,7 @@ export class Projection<S, A> implements Gettable<S, A> {
    * )
    * // Or:
    * const combined = pipe(
-   *   Projection.merge(p1, p2, p3),
+   *   Projection.createTuple(p1, p2, p3),
    *   Projection.pipeMap((a, b, c) => ({
    *     d: `${a.value}-${b.type}-${c.foo}`
    *   }))
@@ -245,7 +245,7 @@ export class Projection<S, A> implements Gettable<S, A> {
    *
    * @see Projection.mapN
    */
-  public static merge<T extends GettableTuple<unknown, TupleType>>(...projections: T): T {
+  public static createTuple<T extends GettableTuple<unknown, TupleType>>(...projections: T): T {
     return projections
   }
 }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -118,9 +118,9 @@ export class Projection<S, A> implements Gettable<S, A> {
   /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
   public combine<Types extends TupleType, R>(
     ss: GettableTuple<S, Types>,
-    f: (arg_0: A, ...args: Types) => R
+    f: FunctionN<[A, ...Types], R>
   ): Projection<S, R>
-  public combine<B, R>(ss: Gettable<S, B>, f: (arg_0: A, arg_1: B) => R): Projection<S, R>
+  public combine<B, R>(ss: Gettable<S, B>, f: FunctionN<[A, B], R>): Projection<S, R>
   public combine<Types extends TupleType, R>(ss: any, f: any): Projection<S, R> {
     const ps: GettableTuple<S, [A, ...Types]> = Array.isArray(ss)
       ? [this, ...ss]
@@ -187,7 +187,7 @@ export class Projection<S, A> implements Gettable<S, A> {
    */
   public static mapN<S, A, Types extends TupleType, R>(
     projections: GettableTuple<S, [A, ...Types]>,
-    f: (...args: [A, ...Types]) => R
+    f: FunctionN<[A, ...Types], R>
   ): Projection<S, R> {
     return Projection.of(
       flow(


### PR DESCRIPTION
1. Got `mapN` and `combine` to have correct return type
2. Got `mapN` and `combine` to not need `as const` to be applied to the parameter
3. Add `tsd` to test the type inferences are all correct